### PR TITLE
Add reported successes on Forma, Elipsa 2E and Aura H2O devices to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 Install scripts for getting [Tailscale](https://tailscale.com) running on Kobo e-readers and persisting through reboots.
 
 ## Supported devices
-- *Kobo Libra 2*
-- *Koba Libra Colour*/*Koba Libra Color*
+- *Kobo Libra 2*/*Forma*/*Aura H2O Edition 2* (via [libra2](libra2/README.md))
+- *Koba Libra Colour*/*Koba Libra Color*/*Elipsa 2E* (via [libra-color](libra-color/README.md))
 - *Kobo Clara BW*
 
 If you have another device and would like to contribute, please open a PR!
 
 ## Installation
-> [!NOTE]  
+> [!NOTE]
 > The version of Tailscale to install can be chosen by editing the `TAILSCALE_VERSION` variable in `install-tailscale.sh`.
 
 1. Download this repo onto your Kobo e-reader's onboard storage and find your device.

--- a/libra2/install-tailscale.sh
+++ b/libra2/install-tailscale.sh
@@ -4,7 +4,7 @@ set -e
 
 # Set what version of tailscale you would like to install here.
 # You can find the latest version at https://pkgs.tailscale.com/stable/#static
-export TAILSCALE_VERSION=1.48.1
+export TAILSCALE_VERSION=1.76.6
 
 echo
 echo "Installing tailscale ${TAILSCALE_VERSION} for Kobo Libra 2!"


### PR DESCRIPTION
Since users have reported these two devices as working, it seems worthwhile adding this to the README.

I also bumped the `TAILSCALE_VERSION` since the version in the script is very old.

Resolves #5, #11
